### PR TITLE
feat: 디버깅을 용이하게 하기 위해 Logger 도입

### DIFF
--- a/MenuBarPhoto.xcodeproj/project.pbxproj
+++ b/MenuBarPhoto.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		CE260D462C6F9193004B154F /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = CE260D452C6F9193004B154F /* .swiftlint.yml */; };
 		CE53247C2C6B607C00A04FB6 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CE53247B2C6B607C00A04FB6 /* Assets.xcassets */; };
 		CE53247F2C6B607C00A04FB6 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = CE53247E2C6B607C00A04FB6 /* Preview Assets.xcassets */; };
+		CE8240942D0853C400AF0536 /* Loggers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8240932D0853C400AF0536 /* Loggers.swift */; };
 		CE8B02592CEF78DC00E5538B /* PhotoService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8B02582CEF78DC00E5538B /* PhotoService.swift */; };
 		CEAB4B802CD4A4F00029F848 /* PhotoScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAB4B7F2CD4A4F00029F848 /* PhotoScrollView.swift */; };
 		CEAB4B822CD4A8EB0029F848 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAB4B812CD4A8EB0029F848 /* main.swift */; };
@@ -55,6 +56,7 @@
 		CE53247B2C6B607C00A04FB6 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		CE53247E2C6B607C00A04FB6 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		CE5324802C6B607C00A04FB6 /* MenuBarPhoto.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MenuBarPhoto.entitlements; sourceTree = "<group>"; };
+		CE8240932D0853C400AF0536 /* Loggers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Loggers.swift; sourceTree = "<group>"; };
 		CE8B02582CEF78DC00E5538B /* PhotoService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoService.swift; sourceTree = "<group>"; };
 		CEAB4B7F2CD4A4F00029F848 /* PhotoScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoScrollView.swift; sourceTree = "<group>"; };
 		CEAB4B812CD4A8EB0029F848 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
@@ -201,6 +203,7 @@
 		CE8B025A2CEF7D2900E5538B /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
+				CE8240932D0853C400AF0536 /* Loggers.swift */,
 				CECBE3102CE0BB8300352A24 /* RatingUtility.swift */,
 			);
 			path = Utilities;
@@ -346,6 +349,7 @@
 				CE235E482CC2537200BF3DFD /* CropImageView.swift in Sources */,
 				CE235E4E2CC2537200BF3DFD /* UnderlyingImageView.swift in Sources */,
 				CE260D312C6F8FBD004B154F /* Constants.swift in Sources */,
+				CE8240942D0853C400AF0536 /* Loggers.swift in Sources */,
 				CE260D2E2C6F8FB7004B154F /* SettingsView.swift in Sources */,
 				CE260D382C6F9021004B154F /* Model.xcdatamodeld in Sources */,
 				CE14741E2CE6380700975773 /* Image.swift in Sources */,

--- a/MenuBarPhoto/Core/CropImage/UnderlyingImageView.swift
+++ b/MenuBarPhoto/Core/CropImage/UnderlyingImageView.swift
@@ -87,7 +87,6 @@ struct UnderlyingImageView: View {
         guard viewSize != .zero else { return }
         let widthScale = viewSize.width / imageWidth
         let heightScale = viewSize.height / imageHeight
-        print("setInitialScale: widthScale: \(widthScale), heightScale: \(heightScale)")
         scale = min(widthScale, heightScale)
     }
 

--- a/MenuBarPhoto/Model/CoreDataStack.swift
+++ b/MenuBarPhoto/Model/CoreDataStack.swift
@@ -38,8 +38,7 @@ extension CoreDataStack {
         do {
             try persistentContainer.viewContext.save()
         } catch {
-            print("Failed to save the context:", error.localizedDescription)
-
+            logDB.error("Failed to save the context: \(error.localizedDescription)")
         }
     }
 }
@@ -53,7 +52,7 @@ extension CoreDataStack {
         photo.photoData = data
         photo.dateCreated = Date()
         photo.photoId = UUID()
-
+        logPhoto.debug("Save new photo")
         save()
     }
 
@@ -62,11 +61,10 @@ extension CoreDataStack {
         request.sortDescriptors = [NSSortDescriptor(key: "dateCreated", ascending: true)]
 
         do {
-
+            logPhoto.debug("Fetch saved photos")
             return try persistentContainer.viewContext.fetch(request)
-
         } catch {
-            print("Error fetching photos: \(error)")
+            logPhoto.error("Failed to fetch photo: \(error)")
             return []
         }
     }
@@ -82,8 +80,9 @@ extension CoreDataStack {
                 persistentContainer.viewContext.delete(photoToDelete)
                 save()
             }
+            logPhoto.debug("Delete one photo")
         } catch {
-            print("Error deleting photo: \(error)")
+            logPhoto.error("Failed to delete photo: \(error)")
         }
 
     }

--- a/MenuBarPhoto/Utilities/Loggers.swift
+++ b/MenuBarPhoto/Utilities/Loggers.swift
@@ -1,0 +1,16 @@
+//
+//  Loggers.swift
+//  MenuBarPhoto
+//
+//  Created by KHJ on 12/10/24.
+//
+
+import Foundation
+import OSLog
+
+let logPhoto = Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: "photo")
+let logRating = Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: "rating")
+let logDB = Logger(subsystem: Bundle.main.bundleIdentifier ?? "", category: "db")
+
+@available(*, deprecated, message: "Use logger instead")
+func print(_ items: Any...) {}

--- a/MenuBarPhoto/Utilities/RatingUtility.swift
+++ b/MenuBarPhoto/Utilities/RatingUtility.swift
@@ -48,5 +48,6 @@ class RatingUtility {
 
     func didPerformSignificantEvent() {
         Defaults[.ratingEventsCount] += 1
+        logRating.debug("Rating event count increased to \(Defaults[.ratingEventsCount])")
     }
 }


### PR DESCRIPTION
close #18 
- print deprecated하게 해 logger 사용 강요
- 카테코리 별 로그 분석을 위해 Photo, Rating, DB 각각에 해당하는 global logger 생성